### PR TITLE
gvncli: update default port

### DIFF
--- a/cmd/gvncli/main.go
+++ b/cmd/gvncli/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	defaultRPCPort     = "8419"
+	defaultRPCPort     = "8465"
 	defaultRPCHostPort = "localhost:" + defaultRPCPort
 )
 


### PR DESCRIPTION
The default port in the command line utility was not updated. This PR fixes it.